### PR TITLE
set header content-type and encoding for vector.pbf

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -130,6 +130,11 @@ module.exports = function(tilelive, uri) {
             return res.send(404);
           }
 
+          if (ext === 'vector.pbf') {
+            headers['content-type'] = 'application/octet-stream';
+            headers['content-encoding'] = 'deflate';
+          }
+
           res.set(headers);
           return res.send(data);
         });


### PR DESCRIPTION
I add to the headers so that the tiles are decompressed via the deflate algorithm. The tiles are compressed, and the browser needs to see this in the header so that it can know to "inflate" the deflated tile. Deflate is similar in nature to gzip.
