### PR TITLE
Add UTFGrid support directly rather than via tilelive module.

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -153,7 +153,7 @@ module.exports = function(tilelive, options) {
         // validate format / extension
         var ext = getExtension(info.format);
 
-        if (ext !== req.params.format) {
+        if (ext !== req.params.format && ("grid.json" == req.params.format && !source["getGrid"]) ) {
           debug("Invalid format '%s', expected '%s'", req.params.format, ext);
           res.set(populateHeaders({}, params, { 404: true, invalidFormat: true }));
           return res.status(404).end();
@@ -178,7 +178,12 @@ module.exports = function(tilelive, options) {
           return res.status(404).end();
         }
 
-        return source.getTile(z, x, y, function(err, data, headers) {
+        var getfn = source.getTile;
+        if ("grid.json" == req.params.format) {
+          getfn = source.getGrid;
+        }
+
+        return getfn(z, x, y, function(err, data, headers) {
           headers = normalizeHeaders(headers || {});
 
           if (err) {
@@ -193,6 +198,12 @@ module.exports = function(tilelive, options) {
           if (data === null || data === undefined) {
             res.set(populateHeaders(headers, params, { 404: true }));
             return res.status(404).end();
+          }
+
+          // This happens if we called getTile and got an object back.
+          // We need to serialize it to JSON before returning the response
+          if (headers["content-type"] && headers["content-type"] == "application/json") {
+            data = JSON.stringify(data);
           }
 
           if (!headers["content-md5"]) {
@@ -234,6 +245,13 @@ module.exports = function(tilelive, options) {
 
         info.tiles = [uri];
         info.tilejson = "2.0.0";
+        if (source["getGrid"]) {
+            var griduri = "http://" + req.headers.host +
+              path.normalize(path.dirname(req.originalUrl) +
+                             tilePath.replace("{format}",
+                                              "grid.json"));
+            info.grids = [griduri];
+        }
 
         res.set(populateHeaders({}, params, { 200: true }));
         return res.send(info);


### PR DESCRIPTION
This change exposes the `grids` element in the TileJSON `index.json` descriptor for a tile source, and
if a tile is requested with the extension `.grid.json`, and the tile source supports UTF grids, `getGrid` will be called instead, and the response data will be JSON stringified.