### PR TITLE
Add endpoint serving static maps (by stitching tiles)

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -4,18 +4,20 @@ var crypto = require("crypto"),
     path = require("path"),
     url = require("url");
 
-var cachecache = require("cachecache"),
+var abaculus = require("abaculus"),
+    cachecache = require("cachecache"),
     clone = require("clone"),
     debug = require("debug"),
     express = require("express"),
     handlebars = require("handlebars"),
     mercator = new (require("sphericalmercator"))();
 
-var abaculus = require('abaculus');
-
 var tessera = require("./index");
 
 debug = debug("tessera");
+
+var FLOAT_PATTERN = "[+-]?(?:\\d+|\\d+\.?\\d+)";
+var SCALE_PATTERN = "@[123]x";
 
 // TODO a more complete implementation of this exists...somewhere
 var getExtension = function(format) {
@@ -27,6 +29,10 @@ var getExtension = function(format) {
   default:
     return format;
   }
+};
+
+var getScale = function(scale) {
+  return (scale || "@1x").slice(1, 2) | 0;
 };
 
 var normalizeHeaders = function(headers) {
@@ -84,7 +90,7 @@ module.exports = function(tilelive, options) {
   }
 
   tilePattern = tilePath
-    .replace(/\.(?!.*\.)/, ":scale(@[23]x)?.")
+    .replace(/\.(?!.*\.)/, ":scale(" + SCALE_PATTERN + ")?.")
     .replace(/\./g, "\.")
     .replace("{z}", ":z(\\d+)")
     .replace("{x}", ":x(\\d+)")
@@ -152,13 +158,13 @@ module.exports = function(tilelive, options) {
 
         if (ext !== format) {
           debug("Invalid format '%s', expected '%s'", format, ext);
-          return callback(404, 'Invalid format', populateHeaders({}, params, { 404: true, invalidFormat: true }));
+          return callback(null, null, populateHeaders({}, params, { 404: true, invalidFormat: true }));
         }
 
         // validate zoom
         if (z < info.minzoom || z > info.maxzoom) {
           debug("Invalid zoom:", z);
-          return callback(404, 'Invalid zoom', populateHeaders({}, params, { 404: true, invalidZoom: true }));
+          return callback(null, null, populateHeaders({}, params, { 404: true, invalidZoom: true }));
         }
 
         // validate coords against bounds
@@ -169,7 +175,7 @@ module.exports = function(tilelive, options) {
             y < xyz.minY ||
             y > xyz.maxY) {
           debug("Invalid coordinates: %d,%d relative to bounds:", x, y, xyz);
-          return callback(404, 'Invalid coordinates', populateHeaders({}, params, { 404: true, invalidCoordinates: true }));
+          return callback(null, null, populateHeaders({}, params, { 404: true, invalidCoordinates: true }));
         }
 
         return source.getTile(z, x, y, function(err, data, headers) {
@@ -177,14 +183,14 @@ module.exports = function(tilelive, options) {
 
           if (err) {
             if (err.message.match(/Tile|Grid does not exist/)) {
-              return callback(404, '', populateHeaders(headers, params, { 404: true }));
+              return callback(null, null, populateHeaders(headers, params, { 404: true }));
             }
 
             return callback(err);
           }
 
           if (data === null || data === undefined) {
-            return callback(404, '', populateHeaders(headers, params, { 404: true }));
+            return callback(null, null, populateHeaders(headers, params, { 404: true }));
           }
 
           if (!headers["content-md5"]) {
@@ -204,47 +210,55 @@ module.exports = function(tilelive, options) {
   };
 
   app.get(tilePattern, function(req, res, next) {
-    return getTile(req.params.z | 0, req.params.x | 0, req.params.y | 0,
-        (req.params.scale || "@1x").slice(1, 2), req.params.format,
-        function(status, data, headers) {
-          if (status && Number(status) == NaN) {
-            return next(status);
-          }
-          res.set(headers);
-          res.status(status || 200);
-          return res.send(data);
-        }, res, next);
+    var z = req.params.z | 0,
+        x = req.params.x | 0,
+        y = req.params.y | 0,
+        scale = getScale(req.params.scale),
+        format = req.params.format;
+    return getTile(z, x, y, scale, format, function(err, data, headers) {
+        if (err && !err.status) {
+          return next(err);
+        }
+        res.set(headers);
+        res.status((err && err.status) || 200);
+        return res.send((err && err.message) || data);
+    }, res, next);
   });
 
-  var floatPattern = "[+-]?(?:\\d+|\\d+\.?\\d+)";
   var staticPattern =
-    "/static/:lon(" + floatPattern + "),:lat(" + floatPattern + "),:z(\\d+)/" +
-    ":width(\\d+)x:height(\\d+):scale(@[123]x)?\.:format([\\w\\.]+)";
+    "/static/:lon(" + FLOAT_PATTERN + "),:lat(" + FLOAT_PATTERN + "),:z(\\d+)/" +
+    ":width(\\d+)x:height(\\d+):scale(" + SCALE_PATTERN + ")?\.:format([\\w\\.]+)";
 
   app.get(staticPattern, function(req, res, next) {
-    var scale = (req.params.scale || "@1x").slice(1, 2) | 0;
-    var format = req.params.format;
-    var params = {
-      zoom: req.params.z | 0,
-      scale: scale,
-      center: {
-        x: parseFloat(req.params.lon),
-        y: parseFloat(req.params.lat),
-        w: req.params.width | 0,
-        h: req.params.height | 0
-      },
-      format: format,
-      getTile: function(z, x, y, callback) {
-        return getTile(z, x, y, scale, format, callback);
-      }
-    };
-    return abaculus(params, function(status, data, headers) {
-      if (status && Number(status) == NaN) {
-        return next(status);
+    var scale = getScale(req.params.scale),
+        format = req.params.format,
+        params = {
+          zoom: req.params.z | 0,
+          scale: scale,
+          center: {
+            x: +req.params.lon,
+            y: +req.params.lat,
+            w: req.params.width | 0,
+            h: req.params.height | 0
+          },
+          format: format,
+          getTile: function(z, x, y, callback) {
+            return getTile(z, x, y, scale, format, function(err, data, headers) {
+              if (!err && data == null) {
+                err = new Error('Not found');
+                err.status = 404;
+              }
+              callback(err, data, headers);
+            });
+          }
+        };
+    return abaculus(params, function(err, data, headers) {
+      if (err && !err.status) {
+        return next(err);
       }
       res.set(headers);
-      res.status(status || 200);
-      return res.send(data);
+      res.status((err && err.status) || 200);
+      return res.send((err && err.message) || data);
     });
   });
 

--- a/lib/app.js
+++ b/lib/app.js
@@ -11,6 +11,8 @@ var cachecache = require("cachecache"),
     handlebars = require("handlebars"),
     mercator = new (require("sphericalmercator"))();
 
+var abaculus = require('abaculus');
+
 var tessera = require("./index");
 
 debug = debug("tessera");
@@ -122,48 +124,41 @@ module.exports = function(tilelive, options) {
     sourceURIs[scale] = retinaURI;
   });
 
-  app.get(tilePattern, function(req, res, next) {
-    var z = req.params.z | 0,
-        x = req.params.x | 0,
-        y = req.params.y | 0,
-        scale = (req.params.scale || "@1x").slice(1, 2),
-        sourceURI = sourceURIs[scale],
+  var getTile = function(z, x, y, scale, format, callback) {
+    var sourceURI = sourceURIs[scale],
         params = {
           tile: {
             zoom: z,
             x: x,
             y: y,
-            format: req.params.format,
+            format: format,
             retina: scale > 1,
             scale: scale
           }
         };
 
-
     return tilelive.load(sourceURI, function(err, source) {
       if (err) {
-        return next(err);
+        return callback(err);
       }
 
       return tessera.getInfo(source, function(err, info) {
         if (err) {
-          return next(err);
+          return callback(err);
         }
 
         // validate format / extension
         var ext = getExtension(info.format);
 
-        if (ext !== req.params.format) {
-          debug("Invalid format '%s', expected '%s'", req.params.format, ext);
-          res.set(populateHeaders({}, params, { 404: true, invalidFormat: true }));
-          return res.status(404).end();
+        if (ext !== format) {
+          debug("Invalid format '%s', expected '%s'", format, ext);
+          return callback(404, 'Invalid format', populateHeaders({}, params, { 404: true, invalidFormat: true }));
         }
 
         // validate zoom
         if (z < info.minzoom || z > info.maxzoom) {
           debug("Invalid zoom:", z);
-          res.set(populateHeaders({}, params, { 404: true, invalidZoom: true }));
-          return res.status(404).end();
+          return callback(404, 'Invalid zoom', populateHeaders({}, params, { 404: true, invalidZoom: true }));
         }
 
         // validate coords against bounds
@@ -174,8 +169,7 @@ module.exports = function(tilelive, options) {
             y < xyz.minY ||
             y > xyz.maxY) {
           debug("Invalid coordinates: %d,%d relative to bounds:", x, y, xyz);
-          res.set(populateHeaders({}, params, { 404: true, invalidCoordinates: true }));
-          return res.status(404).end();
+          return callback(404, 'Invalid coordinates', populateHeaders({}, params, { 404: true, invalidCoordinates: true }));
         }
 
         return source.getTile(z, x, y, function(err, data, headers) {
@@ -183,16 +177,14 @@ module.exports = function(tilelive, options) {
 
           if (err) {
             if (err.message.match(/Tile|Grid does not exist/)) {
-              res.set(populateHeaders(headers, params, { 404: true }));
-              return res.status(404).end();
+              return callback(404, '', populateHeaders(headers, params, { 404: true }));
             }
 
-            return next(err);
+            return callback(err);
           }
 
           if (data === null || data === undefined) {
-            res.set(populateHeaders(headers, params, { 404: true }));
-            return res.status(404).end();
+            return callback(404, '', populateHeaders(headers, params, { 404: true }));
           }
 
           if (!headers["content-md5"]) {
@@ -205,10 +197,54 @@ module.exports = function(tilelive, options) {
             headers["content-encoding"] = headers["content-encoding"] || "gzip";
           }
 
-          res.set(populateHeaders(headers, params, { 200: true }));
-          return res.send(data);
+          return callback(null, data, populateHeaders(headers, params, { 200: true }));
         });
       });
+    });
+  };
+
+  app.get(tilePattern, function(req, res, next) {
+    return getTile(req.params.z | 0, req.params.x | 0, req.params.y | 0,
+        (req.params.scale || "@1x").slice(1, 2), req.params.format,
+        function(status, data, headers) {
+          if (status && Number(status) == NaN) {
+            return next(status);
+          }
+          res.set(headers);
+          res.status(status || 200);
+          return res.send(data);
+        }, res, next);
+  });
+
+  var floatPattern = "[+-]?(?:\\d+|\\d+\.?\\d+)";
+  var staticPattern =
+    "/static/:lon(" + floatPattern + "),:lat(" + floatPattern + "),:z(\\d+)/" +
+    ":width(\\d+)x:height(\\d+):scale(@[123]x)?\.:format([\\w\\.]+)";
+
+  app.get(staticPattern, function(req, res, next) {
+    var scale = (req.params.scale || "@1x").slice(1, 2) | 0;
+    var format = req.params.format;
+    var params = {
+      zoom: req.params.z | 0,
+      scale: scale,
+      center: {
+        x: parseFloat(req.params.lon),
+        y: parseFloat(req.params.lat),
+        w: req.params.width | 0,
+        h: req.params.height | 0
+      },
+      format: format,
+      getTile: function(z, x, y, callback) {
+        return getTile(z, x, y, scale, format, callback);
+      }
+    };
+    return abaculus(params, function(status, data, headers) {
+      if (status && Number(status) == NaN) {
+        return next(status);
+      }
+      res.set(headers);
+      res.status(status || 200);
+      return res.send(data);
     });
   });
 

--- a/lib/app.js
+++ b/lib/app.js
@@ -217,12 +217,15 @@ module.exports = function(tilelive, options) {
         scale = getScale(req.params.scale),
         format = req.params.format;
     return getTile(z, x, y, scale, format, function(err, data, headers) {
-        if (err && !err.status) {
+        if (err) {
           return next(err);
         }
         res.set(headers);
-        res.status((err && err.status) || 200);
-        return res.send((err && err.message) || data);
+        if (data == null) {
+          return res.status(404).send('Not found');
+        } else {
+          return res.status(200).send(data);
+        }
     }, res, next);
   });
 

--- a/lib/app.js
+++ b/lib/app.js
@@ -18,7 +18,7 @@ var tessera = require("./index");
 debug = debug("tessera");
 
 var FLOAT_PATTERN = "[+-]?(?:\\d+|\\d+\.?\\d+)";
-var SCALE_PATTERN = "@[123]x";
+var SCALE_PATTERN = "@[23]x";
 
 // TODO a more complete implementation of this exists...somewhere
 var getExtension = function(format) {

--- a/lib/app.js
+++ b/lib/app.js
@@ -2,7 +2,8 @@
 
 var crypto = require("crypto"),
     path = require("path"),
-    url = require("url");
+    url = require("url"),
+    util = require("util");
 
 var abaculus = require("abaculus"),
     cachecache = require("cachecache"),
@@ -225,22 +226,14 @@ module.exports = function(tilelive, options) {
     }, res, next);
   });
 
-  var staticPattern =
-    "/static/:lon(" + FLOAT_PATTERN + "),:lat(" + FLOAT_PATTERN + "),:z(\\d+)/" +
-    ":width(\\d+)x:height(\\d+):scale(" + SCALE_PATTERN + ")?\.:format([\\w\\.]+)";
-
-  app.get(staticPattern, function(req, res, next) {
+  var processStaticMap = function(areaParams, req, res, next) {
     var scale = getScale(req.params.scale),
         format = req.params.format,
         params = {
           zoom: req.params.z | 0,
           scale: scale,
-          center: {
-            x: +req.params.lon,
-            y: +req.params.lat,
-            w: req.params.width | 0,
-            h: req.params.height | 0
-          },
+          bbox: areaParams.bbox,
+          center: areaParams.center,
           format: format,
           getTile: function(z, x, y, callback) {
             return getTile(z, x, y, scale, format, function(err, data, headers) {
@@ -260,6 +253,36 @@ module.exports = function(tilelive, options) {
       res.status((err && err.status) || 200);
       return res.send((err && err.message) || data);
     });
+  };
+
+  var staticPattern = "/static/%s:scale(" + SCALE_PATTERN + ")?\.:format([\\w\\.]+)";
+
+  var centerPattern = util.format(':lon(%s),:lat(%s),:z(\\d+)/:width(\\d+)x:height(\\d+)',
+                                  FLOAT_PATTERN, FLOAT_PATTERN);
+
+  app.get(util.format(staticPattern, centerPattern), function(req, res, next) {
+    return processStaticMap({
+      center: {
+        x: +req.params.lon,
+        y: +req.params.lat,
+        w: req.params.width | 0,
+        h: req.params.height | 0
+      }
+    }, req, res, next);
+  });
+
+  var boundsPattern = util.format(':minx(%s),:miny(%s),:maxx(%s),:maxy(%s)/:z(\\d+)',
+                                  FLOAT_PATTERN, FLOAT_PATTERN, FLOAT_PATTERN, FLOAT_PATTERN);
+
+  app.get(util.format(staticPattern, boundsPattern), function(req, res, next) {
+    return processStaticMap({
+      bbox: [
+        +req.params.minx,
+        +req.params.miny,
+        +req.params.maxx,
+        +req.params.maxy
+      ]
+    }, req, res, next);
   });
 
   app.get("/index.json", function(req, res, next) {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "prepublish": "npm install bower && bower install"
   },
   "dependencies": {
+    "abaculus": "^1.2.1",
     "cachecache": "^1.0.1",
     "clone": "^1.0.2",
     "cors": "^2.5.2",


### PR DESCRIPTION
This PR adds `/static/{lon},{lat},{zoom}/{width}x{height}[@{scale}x].{format}` endpoint (syntax similar to https://www.mapbox.com/developers/api/static/) which serves requested static image.

The static image is stitched from individual tiles using https://github.com/mapbox/abaculus.

I had to do some refactoring (extracting code from the tile route into `getTile` function) to prevent code duplicity and slightly modify related error reporting. Hope this was the right way to handle this and it doesn't break anything.