### PR TITLE
Allow arbitrary scales to be specified, e.g. @4.2x (particularly useful for static api and printing)

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -18,7 +18,7 @@ var tessera = require("./index");
 debug = debug("tessera");
 
 var FLOAT_PATTERN = "[+-]?(?:\\d+|\\d+\.?\\d+)";
-var SCALE_PATTERN = "@[23]x";
+var SCALE_PATTERN = "@(?:\\d+|\\d+\.?\\d+)x";
 
 // TODO a more complete implementation of this exists...somewhere
 var getExtension = function(format) {
@@ -33,7 +33,7 @@ var getExtension = function(format) {
 };
 
 var getScale = function(scale) {
-  return (scale || "@1x").slice(1, 2) | 0;
+  return parseFloat((scale || "@1x").slice(1));
 };
 
 var normalizeHeaders = function(headers) {
@@ -121,18 +121,50 @@ module.exports = function(tilelive, options) {
     1: uri
   };
 
-  [2, 3].forEach(function(scale) {
-    var retinaURI = clone(uri);
+  // We cache 100 sourceURIs, randomly evict when over limit
+  var sourceURIsCacheKeys = [];
+  var sourceURIsCacheSizeLimit = 100;
+
+  var makeScaledSourceURI = function(scale, permanent) {
+    var retinaURI = clone(uri),
+        randomIndex;
 
     retinaURI.query.scale = scale;
     // explicitly tell tilelive-mapnik to use larger tiles
-    retinaURI.query.tileSize = scale * 256;
+    retinaURI.query.tileSize = (scale * 256) | 0;
 
+    if (!permanent) {
+      // Save the URI to the uri cache, but limit its size
+      while (sourceURIsCacheKeys.length > sourceURIsCacheSizeLimit) {
+        // Delete random sourceURI
+        randomIndex = Math.floor(Math.random()*sourceURIsCacheKeys.length);
+        delete sourceURIs[sourceURIsCacheKeys[randomIndex]];
+        sourceURIsCacheKeys.splice(randomIndex, 1);
+      }
+      sourceURIsCacheKeys.push(scale);
+    }
     sourceURIs[scale] = retinaURI;
+
+    return retinaURI;
+  };
+
+  // make scaled source urls for retina @2x and @3x
+  [2, 3].forEach(function(scale) {
+    // these are not added to sourceURIsCacheKeys so that they are not ever removed from the cache
+    makeScaledSourceURI(scale, true);
   });
 
+  var getSourceURI = function(scale) {
+    if (scale in sourceURIs) {
+      return sourceURIs[scale];
+    } else {
+      // scaled uri does not exist so we make one
+      return makeScaledSourceURI(scale);
+    }
+  };
+
   var getTile = function(z, x, y, scale, format, callback) {
-    var sourceURI = sourceURIs[scale],
+    var sourceURI = getSourceURI(scale),
         params = {
           tile: {
             zoom: z,


### PR DESCRIPTION
I am using tessera to generate static maps for printing (replacing similar functionality in Mapbox Studio Classic), to do this you need to be able to set arbitrary scales rather than just @1x, @2x, or @3x (actually @1x can’t currently be explicitly be set) for example @4.2x. This is needed so that you can create images of the correct size and DPI.

This also implements a cache of 100 sourceURIs (randomly evicted) so that it isn't re-creating the sourceURI for each tile drawn. If we were to save the sourceURIs permanently the list would grow infinitely over time as more unique scales are used. Scales 1, 2 and 3 are never evicted from the cache.

This functionality may want to be behind a configuration options so that it’s not available by default on a publicly accessible server?