### PR TITLE
Regular expression supposed to match "Tile does not exist" was matching anything with Tile

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -183,7 +183,7 @@ module.exports = function(tilelive, options) {
           headers = normalizeHeaders(headers || {});
 
           if (err) {
-            if (err.message.match(/Tile|Grid does not exist/)) {
+            if (err.message.match(/(Tile|Grid) does not exist/)) {
               return callback(null, null, populateHeaders(headers, params, { 404: true }));
             }
 


### PR DESCRIPTION
This was causing error messages that contained the word "Tile" to not be logged, and 404 to be returned instead