### PR TITLE
add support for https requests - use same protocol as request is made…

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -53,7 +53,7 @@ var md5sum = function(data) {
 };
 
 module.exports = function(tilelive, options) {
-  var app = express().disable("x-powered-by"),
+  var app = express().disable("x-powered-by").enable("trust proxy"),
       templates = {},
       uri = options,
       tilePath = "/{z}/{x}/{y}.{format}",
@@ -298,7 +298,7 @@ module.exports = function(tilelive, options) {
           return next(err);
         }
 
-        var uri = "http://" + req.headers.host +
+        var uri = req.protocol + "://" + req.headers.host +
           (path.dirname(req.originalUrl) +
                          tilePath.replace("{format}",
                                           getExtension(info.format))).replace(/\/+/g, "/");


### PR DESCRIPTION
Let's say we need to server tiles using safe connection. Problem is that tile url is hard coded to `http://`.

One possible solution is to rely on headers `X-Forwarded-*`.