### PR TITLE
Fix 404s for empty, out of bounds, overzoomed etc vector tiles

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -178,11 +178,14 @@ module.exports = function(tilelive, options) {
           headers = normalizeHeaders(headers || {});
 
           if (err) {
-            if (err.message.match(/(Tile|Grid) does not exist/)) {
+            if (ext === "pbf" && err.message.match(/(Tile|Grid) does not exist/)) {
+              // Stop 404 errors for empty vector tiles, but keep 404s for images or out of bounds etc.
+              data = new Buffer(0);
+            } else if (err.message.match(/(Tile|Grid) does not exist/)) {
               return callback(null, null, populateHeaders(headers, params, { 404: true }));
+            } else {
+              return callback(err);
             }
-
-            return callback(err);
           }
 
           if (data === null || data === undefined) {
@@ -215,8 +218,8 @@ module.exports = function(tilelive, options) {
         if (err) {
           return next(err);
         }
-        if (data == null && format !== "pbf") {
-          return res.status(404).send("Not found");
+        if (data == null) {
+          return res.status(404).send('Not found');
         } else {
           res.set(headers);
           return res.status(200).send(data);
@@ -236,7 +239,7 @@ module.exports = function(tilelive, options) {
           getTile: function(z, x, y, callback) {
             return getTile(z, x, y, scale, format, function(err, data, headers) {
               if (!err && data == null) {
-                err = new Error("Not found");
+                err = new Error('Not found');
                 err.status = 404;
               }
               callback(err, data, headers);


### PR DESCRIPTION
Before, all errors and empty vector tiles were returned as 404 errors. Currently, Tessera doesn't ever return 404s for vector tile layers. It would be better if Tessera returned 404 responses on errors and empty data 200 responses for empty tiles.

Fixes #53 and #49.