### PR TITLE
Use X-Forwarded-Host header, if provided

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -317,7 +317,8 @@ module.exports = function(tilelive, options) {
         }
 
         var protocol = req.headers['x-forwarded-proto'] || req.protocol;
-        var uri = protocol + "://" + req.headers.host +
+        var host = req.headers['x-forwarded-host'] || req.headers.host;
+        var uri = protocol + "://" + host +
           (path.dirname(req.originalUrl) +
                          tilePath.replace("{format}",
                                           getExtension(info.format))).replace(/\/+/g, "/");


### PR DESCRIPTION
Enables us to run tessera behind a reverse proxy, not replying the internal name of the service.