### PR TITLE
Ignore faulty x-forwarded-proto.

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -256,7 +256,7 @@ module.exports = function(tilelive, options) {
           return next(err);
         }
 
-        var protocol = req.headers['x-forwarded-proto'] || req.protocol;
+        var protocol = (req.headers['x-forwarded-proto'] || '').match(/^[a-z]+$/) ? req.headers['x-forwarded-proto'] : req.protocol;
         var host = req.headers['x-forwarded-host'] || req.headers.host;
         var uri = protocol + "://" + host +
           (path.dirname(req.originalUrl) +


### PR DESCRIPTION
Fixes #89.

This is the least impactful way to workaround the issue. Basically, if x-forwarded-proto doesn't look like either a plain "http" or "https", fall back to the actual protocol used.