### PR TITLE
Use server instead of this

### DIFF
--- a/server.js
+++ b/server.js
@@ -128,7 +128,7 @@ module.exports = function(opts, callback) {
   }
 
   var handler = process.env.SOCKET || opts.socket || process.env.PORT || opts.port;
-  var server = app.listen(handler, process.env.HOST || opts.bind, function() {
+  var server = app.listen(handler, process.env.HOST || opts.bind, function(server) {
     var endpoint;
     if (opts.socket) {
       endpoint = opts.socket;
@@ -141,7 +141,7 @@ module.exports = function(opts, callback) {
       // allow the socket to be accessed by other users/groups
       fs.chmodSync(opts.socket, "1766");
     } else {
-      endpoint = "http://" + this.address().address + ':' + this.address().port;
+      endpoint = "http://" + server.address().address + ':' + server.address().port;
     }
     console.log("Listening at %s", endpoint);
 

--- a/server.js
+++ b/server.js
@@ -128,7 +128,7 @@ module.exports = function(opts, callback) {
   }
 
   var handler = process.env.SOCKET || opts.socket || process.env.PORT || opts.port;
-  var server = app.listen(handler, process.env.HOST || opts.bind, function(server) {
+  var server = app.listen(handler, process.env.HOST || opts.bind, function() {
     var endpoint;
     if (opts.socket) {
       endpoint = opts.socket;


### PR DESCRIPTION
Fixes a problem with Bun on Linux that prevented the server from starting. It seemed to use undocumented behaviour.