### PR TITLE
replace parseInt for the number of processes in multiprocessing mode

### DIFF
--- a/bin/tessera.js
+++ b/bin/tessera.js
@@ -13,7 +13,7 @@ program
   .option(
     "-P, --processes <PROCESSES>",
     "Number of processes to start",
-    parseInt,
+    parseFloat,
     require("os").cpus().length
   )
   .option(


### PR DESCRIPTION
replace parseInt for the number of processes in multiprocessing mode with parseFloat -- this seems to prevent cases where parseInt inexplicably returns NaN. Should resolve this issue https://github.com/mojodna/tessera/issues/108